### PR TITLE
ci: remove qemu setup from native build jobs

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -17,8 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
-      - name: qemu
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0 https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3 https://github.com/actions/cache/releases/tag/v5.0.3
         with:
@@ -54,8 +52,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
-      - name: qemu
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0 https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3 https://github.com/actions/cache/releases/tag/v5.0.3
         with:


### PR DESCRIPTION
closes #39 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `docker/setup-qemu-action` from native Docker build jobs to avoid unnecessary emulation and simplify CI. Applies to the linux/amd64 and ubuntu-24.04-arm jobs in `.github/workflows/ci-docker.yml`, keeping Buildx only; aligns with #39.

<sup>Written for commit bc8bb6b95eb94d6245892690b05daba8486670c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

